### PR TITLE
Fixed trefle API data validation bug

### DIFF
--- a/src/pages/PlantPage/PlantPage.tsx
+++ b/src/pages/PlantPage/PlantPage.tsx
@@ -38,7 +38,7 @@ const PlantPage = () => {
     agent.Trefle.details(
       plantName.replace(/\s*\([^)]*\)\s*/g, "").replace(" ", ",")
     ).then((treflePlant) => {
-      treflePlant.name === undefined
+      treflePlant.meta.total === 0
         ? dispatch(updateCurrentTreflePlant(new TreflePlant()))
         : dispatch(updateCurrentTreflePlant(treflePlant.data[0]));
     });


### PR DESCRIPTION
Created validation to check if meta.total equals 0. If so, instead of setting trefle plant local storage to undefined, it creates an instance of the TreflePlant class and uses the default values instead.