### PR TITLE
added promise chaining to updateLocalStorageZone

### DIFF
--- a/src/Components/zones/EditZone.tsx
+++ b/src/Components/zones/EditZone.tsx
@@ -16,7 +16,6 @@ import { Formik, Form, Field, ErrorMessage } from "formik";
 import * as Yup from "yup";
 import { useSelector } from "react-redux";
 import { RootState } from "../../redux/store";
-import { useEffect } from "react";
 import "../../styles/zones/AddZone.css";
 
 type ZoneBarProps = {
@@ -82,10 +81,6 @@ function EditZone({ fetchZones, setIsShowEdit, isShowEdit }: ZoneBarProps) {
     runtimePerWeek: Yup.number().required("Required field"),
     imagePath: Yup.string().url("Please enter valid URL"),
   });
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [zone]);
 
   return (
     <div>

--- a/src/Components/zones/ZoneCard.tsx
+++ b/src/Components/zones/ZoneCard.tsx
@@ -57,9 +57,11 @@ export default function ZoneCard({
 
   // This gets passed to AddPlant to update and persist gallons on PlantBar
   const updateLocalStorageZone = () => {
-    agent.Zones.details(zone.id).then((zone) => {
-      dispatch(updateCurrentZone(zone));
-    });
+    agent.Zones.details(zone.id)
+      .then((zone) => {
+        dispatch(updateCurrentZone(zone));
+      })
+      .then(() => setIsShowEdit(true));
   };
 
   const updateLocalStoragePlants = () => {
@@ -79,13 +81,8 @@ export default function ZoneCard({
     updateLocalStoragePlants();
   };
 
-  // Temporary fix: Used setTimeout to delay so that the edit modal will grab the most recent local storage value
-  // See EditZone for bug comment
   const showEdit = () => {
     updateLocalStorageZone();
-    setTimeout(() => {
-      setIsShowEdit(true);
-    }, 100);
     console.log("%cZoneCard: Edit Clicked", "color:#1CA1E6");
   };
 


### PR DESCRIPTION
**Issue**: The issue was that the zone edit component was showing before the fetch was complete.
**Fix**: In updateLocalStorageZone function, added a promise (then) for the setIsShowEdit function. This allowed the fetch and update to complete.